### PR TITLE
Use $DOTNET_ROOT/sdk as inventory dir and sync installed versions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# having this set messes with tests as it'll be outside the sandbox
+DOTNET_ROOT = { value = "", force = true }


### PR DESCRIPTION
As a bonus this allows uninstallation of the SDK.

Fixes #4 